### PR TITLE
Account creation

### DIFF
--- a/app/ts/App.tsx
+++ b/app/ts/App.tsx
@@ -357,9 +357,7 @@ export function App() {
 		if (window.ethereum === undefined) {
 			updateWalletSignals(undefined)
 		} else {
-			window.ethereum.on('accountsChanged', (accounts) => {
-				updateWalletSignals(accounts[0])
-			})
+			window.ethereum.on('accountsChanged', (accounts) => { updateWalletSignals(accounts[0]) })
 			window.ethereum.on('chainChanged', async () => { updateChainId() })
 			try {
 				loadingAccount.value = true


### PR DESCRIPTION
- There's a bug that if you don't connect your wallet at start, and click connect, that new object will not track accountsChanged and chainChanged
- Also we have been showing account fields empty while we load a lot other stuff. Now we show account right after we get it and show spinner for rest stuff (e.g., wallet balances)