### PR TITLE
Shrink size of allowance input fields.

### DIFF
--- a/app/ts/CreateMarketUI/components/CreateMarket.tsx
+++ b/app/ts/CreateMarketUI/components/CreateMarket.tsx
@@ -109,7 +109,7 @@ export const Allowances = ( { maybeWriteClient, universe, marketCreationCostDai,
 					class = 'input reporting-panel-input'
 					type = 'text'
 					placeholder = { '' }
-					style = { { maxWidth: '300px' } }
+					style = { { maxWidth: '100px' } }
 					value = { daiAllowanceToBeSet }
 					sanitize = { (amount: string) => amount.trim() }
 					tryParse = { parse18DecimalBigintForInput }
@@ -134,7 +134,7 @@ export const Allowances = ( { maybeWriteClient, universe, marketCreationCostDai,
 					class = 'input reporting-panel-input'
 					type = 'text'
 					placeholder = ''
-					style = { { maxWidth: '300px' } }
+					style = { { maxWidth: '100px' } }
 					value = { repAllowanceToBeSet }
 					sanitize = { (amount: string) => amount.trim() }
 					tryParse = { parse18DecimalBigintForInput }


### PR DESCRIPTION
300px is quite large, especially if you want to retain the max-width in #142.  It causes overflow in the transaction hash.

Another solution to this would be to put the transaction hash on a whole line by itself after the input buttons, rather than having it part of the grid.  However, I believe it is part of the `SendTransactionButton`, so moving it out of the button element is likely pretty hard.